### PR TITLE
fix: Regression with loading the project in Visual Studio

### DIFF
--- a/lxmonika.sln
+++ b/lxmonika.sln
@@ -1,4 +1,4 @@
-﻿
+﻿+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34316.72
@@ -122,7 +122,7 @@ Global
 		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Debug|x64.ActiveCfg = Debug|x64
 		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Debug|x64.Build.0 = Debug|x64
 		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Debug|x86.ActiveCfg = Debug|Win32
-		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Release|ARM.ActiveCfg = Release|ARM
+		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Release|ARM.ActiveCfg = Release|ARM64
 		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Release|ARM64.ActiveCfg = Release|ARM64
 		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Release|ARM64.Build.0 = Release|ARM64
 		{E0C31EA1-DB35-438A-B840-EFD8C43E4409}.Release|x64.ActiveCfg = Release|x64

--- a/lxmonika.sln
+++ b/lxmonika.sln
@@ -1,4 +1,4 @@
-﻿+
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34316.72


### PR DESCRIPTION
This commit fixes Visual Studio being unable to load the mxhost project when it is relaunched after is it closed Release|ARM has been selected as the current configuration